### PR TITLE
Enable SWR notes polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,8 @@ Visit [http://localhost:3000](http://localhost:3000) in your browser to access t
 - `npm run db:migrate` - Run database migrations
 - `npm run db:studio` - Open Prisma Studio (database GUI)
 - `npm run db:reset` - Reset database and run migrations
+
+## Environment Variables
+
+- `NEXT_PUBLIC_POLL_INTERVAL_MS` - Interval in milliseconds for polling notes
+  updates. Defaults to `5000` if not set.

--- a/lib/hooks/useNotes.ts
+++ b/lib/hooks/useNotes.ts
@@ -1,0 +1,19 @@
+import useSWR from 'swr'
+
+interface NotesResponse {
+  notes: any[]
+}
+
+const fetcher = (url: string) => fetch(url).then(res => res.json())
+
+export default function useNotes(boardId?: string | null) {
+  const refreshInterval = Number(process.env.NEXT_PUBLIC_POLL_INTERVAL_MS) || 5000
+  const url = !boardId
+    ? null
+    : boardId === 'all-notes'
+      ? '/api/boards/all-notes/notes'
+      : `/api/boards/${boardId}/notes`
+  const { data, isLoading, mutate } = useSWR<NotesResponse>(url, fetcher, { refreshInterval })
+
+  return { notes: data?.notes ?? [], isLoading, mutate }
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.59.0",
+    "swr": "^2.2.0",
     "resend": "^4.6.0",
     "tailwind-merge": "^3.3.1",
     "zod": "^3.25.67"


### PR DESCRIPTION
## Summary
- add `swr` dependency
- implement `useNotes` hook with polling
- use the hook in board page and refresh notes after actions
- document `NEXT_PUBLIC_POLL_INTERVAL_MS` env variable

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6889250bdc9483278c8a7e54b4cdcbe0